### PR TITLE
Remove PHP 7 from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ php:
     - 5.4
     - 5.5
     - 5.6
-    - 7.0
-    - nightly
 
 env:
     - TEST_PHP_ARGS="-q"
@@ -25,8 +23,3 @@ before_script:
 
 script:
     - make test
-
-matrix:
-    allow_failures:
-        - php: nightly
-        - php: 7.0


### PR DESCRIPTION
This plugin does not work with PHP 7.0+.